### PR TITLE
Don't remove query string when fetching imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "test": "deno run --allow-all ./test/index.js"
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -68,7 +68,7 @@ async function useResponseCacheElseLoad(options: Options, path: string, headers:
         return responseCache[ path ];
     }
     options.onCacheMiss?.(path);
-    return responseCache[ path ] = await fetch(path.split("?")[ 0 ], { headers });
+    return responseCache[ path ] = await fetch(path, { headers });
 }
 
 async function handeSourceMaps(contents: string, source: Response, headers: Headers) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,16 +1,16 @@
-import {build, stop} from 'https://deno.land/x/esbuild@v0.12.1/mod.js'
-import httpFetch from '../http-fetch.js'
+import { build, stop } from "https://deno.land/x/esbuild@v0.17.15/mod.js";
+import { httpImports } from "../index.ts";
 
-let {outputFiles} = await build({
+let { outputFiles } = await build({
   bundle: true,
-  entryPoints: ['test/hello.jsx'],
-  jsxFactory: 'h',
-  plugins: [httpFetch],
-  write: false
-})
+  entryPoints: ["test/hello.jsx"],
+  jsxFactory: "h",
+  plugins: [httpImports({ defaultToJavascriptIfNothingElseFound: true })],
+  write: false,
+});
 
-eval(outputFiles[0].text)
+eval(outputFiles[0].text);
 // expected: <h1>Hello, world!</h1>
 // actual: <h1>Hello, world!</h1>
 
-stop()
+stop();


### PR DESCRIPTION
I did the following changes:

- leave the full URL when fetching, instead of using only pathname #1 
- fix `test/index.js` file
- add deno.json with a task for `test`